### PR TITLE
Set CN on certificates

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: create CA CSR
   when: not pki_self_sign
   shell: '{{pki_cfssl_root}}/cfssl genkey cacsr.json | {{pki_cfssl_root}}/cfssljson -bare ca'
-  args: 
+  args:
     chdir: '{{pki_dir}}'
     creates: '{{pki_dir}}/ca.csr'
 
@@ -34,7 +34,8 @@
     {{pki_cfssl_root}}/cfssl gencert
     -ca {{pki_dir}}/ca.pem
     -ca-key {{pki_dir}}/ca-key.pem
-    -hostname {{ ([item.cname] + (['localhost', '127.0.0.1'] if item.include_localhost is defined and item.include_localhost else []) + (item.sans|default([])) + (item.altips|default([]))) | join(",") }} csr.json 
+    -cn {{item.cname}}
+    -hostname {{ ([item.cname] + (['localhost', '127.0.0.1'] if item.include_localhost is defined and item.include_localhost else []) + (item.sans|default([])) + (item.altips|default([]))) | join(",") }} csr.json
     | {{pki_cfssl_root}}/cfssljson -bare {{item.cname}}
   args:
     chdir: '{{pki_dir}}'


### PR DESCRIPTION
Some applications require the CN field is set and will not consider SAN values. A [recent change](https://github.com/cloudflare/cfssl/pull/591) to cfssl allows setting CN on the commandline.